### PR TITLE
chore: update default branding to iopeer

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Set default values if not provided
-export AP_APP_TITLE="${AP_APP_TITLE:-Activepieces}"
-export AP_FAVICON_URL="${AP_FAVICON_URL:-https://cdn.activepieces.com/brand/favicon.ico}"
+export AP_APP_TITLE="${AP_APP_TITLE:-IOPeer}"
+export AP_FAVICON_URL="${AP_FAVICON_URL:-https://iopeer.com/favicon.ico}"
 
 # Debug: Print environment variables
 echo "AP_APP_TITLE: $AP_APP_TITLE"

--- a/packages/react-ui/index.html
+++ b/packages/react-ui/index.html
@@ -9,7 +9,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" type="image/x-icon" href="<%= apFavicon %>">
-  <script type='text/javascript'>(function() {var gs = document.createElement('script');gs.src = 'https://join.activepieces.com/pr/js';gs.type = 'text/javascript';gs.async = 'true';gs.onload = gs.onreadystatechange = function() {var rs = this.readyState;if (rs && rs != 'complete' && rs != 'loaded') return;try {growsumo._initialize('pk_hXXmQVEnpqPOxa9D1sD085zFWUWbpwd9'); if (typeof(growsumoInit) === 'function') {growsumoInit();}} catch (e) {}};var s = document.getElementsByTagName('script')[0];s.parentNode.insertBefore(gs, s);})();</script>
+  <script type='text/javascript'>(function() {var gs = document.createElement('script');gs.src = 'https://join.iopeer.com/pr/js';gs.type = 'text/javascript';gs.async = 'true';gs.onload = gs.onreadystatechange = function() {var rs = this.readyState;if (rs && rs != 'complete' && rs != 'loaded') return;try {growsumo._initialize('pk_hXXmQVEnpqPOxa9D1sD085zFWUWbpwd9'); if (typeof(growsumoInit) === 'function') {growsumoInit();}} catch (e) {}};var s = document.getElementsByTagName('script')[0];s.parentNode.insertBefore(gs, s);})();</script>
   <link rel="stylesheet" href="/src/styles.css" />
 </head>
 

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -10,10 +10,10 @@ import { createHtmlPlugin } from 'vite-plugin-html';
 export default defineConfig(({ command, mode }) => {
   const isDev = command === 'serve' || mode === 'development';
 
-  const AP_TITLE = isDev ? 'Activepieces' : '${AP_APP_TITLE}';
+  const AP_TITLE = isDev ? 'IOPeer' : '${AP_APP_TITLE}';
 
   const AP_FAVICON = isDev
-    ? 'https://activepieces.com/favicon.ico'
+    ? 'https://iopeer.com/favicon.ico'
     : '${AP_FAVICON_URL}';
 
   return {


### PR DESCRIPTION
## Summary
- update container defaults to use IOPeer title and favicon values
- align Vite dev/prod HTML injections with new IOPeer branding
- replace remaining Activepieces external script reference in the React UI template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e006c1b51483259c82f016e40f48fb