### PR TITLE
chore: update docker configs for iopeer branding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY --from=build /usr/src/app/packages packages
 # Copy frontend files to Nginx document root directory from build stage
 COPY --from=build /usr/src/app/dist/packages/react-ui /usr/share/nginx/html/
 
-LABEL service=activepieces
+LABEL service=iopeer
 
 # Set up entrypoint script
 COPY docker-entrypoint.sh .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ services:
   db:
     image: postgres:14.4
     environment:
-      POSTGRES_DB: activepieces
+      POSTGRES_DB: iopeer
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: A79Vm5D4p2VQHOp2gd5
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,4 +27,4 @@ volumes:
   redis_data_dev:
 
 networks:
-  activepieces_dev:
+  iopeer_dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3.0'
 services:
-  activepieces:
-    image: ghcr.io/activepieces/activepieces:0.70.2
-    container_name: activepieces
+  iopeer:
+    image: ghcr.io/iopeer/iopeer:latest
+    container_name: iopeer
     restart: unless-stopped
-    ## Enable the following line if you already use AP_EXECUTION_MODE with SANDBOXED or old activepieces, checking the breaking change documentation for more info.
+    ## Enable the following line if you already use AP_EXECUTION_MODE with SANDBOXED or previous IOPeer releases, checking the breaking change documentation for more info.
     ## privileged: true
     ports:
       - '8080:80'
@@ -15,7 +15,7 @@ services:
     volumes:
       - ./cache:/usr/src/app/cache
     networks:
-      - activepieces
+      - iopeer
   postgres:
     image: 'postgres:14.4'
     container_name: postgres
@@ -28,7 +28,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
-      - activepieces
+      - iopeer
   redis:
     image: 'redis:7.0.7'
     container_name: redis
@@ -36,9 +36,9 @@ services:
     volumes:
       - 'redis_data:/data'
     networks:
-      - activepieces
+      - iopeer
 volumes:
   postgres_data:
   redis_data:
 networks:
-  activepieces:
+  iopeer:


### PR DESCRIPTION
## Summary
- point the main docker-compose service to the iopeer image and rename the related network
- switch development and test database/network identifiers to the iopeer name
- rebrand the Dockerfile metadata label to iopeer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e006c239d48325ba45687be241a4c0