### PR TITLE
feat: harden run retries and dashboards

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -1,18 +1,36 @@
 name: Alerts
+
 on:
   workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+    workflows:
+      - Deploy
+    types:
+      - completed
+  schedule:
+    - cron: '0 * * * *'
+      timezone: America/Argentina/Buenos_Aires
+
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Slack (fail only)
-        if: ${{ github.event.workflow_run.conclusion != 'success' }}
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: '{"text":":warning: CI failed on ${{
-            github.repository }} • run: ${{ github.server_url }}/${{
-            github.repository }}/actions/runs/${{ github.run_id }}"}'
+      - name: Determine if alert is required
+        id: determine
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+              echo "send=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "send=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "send=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Send Slack notification
+        if: steps.determine.outputs.send == 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          payload='{ "text": ":rotating_light: Alert IOpeer • Evento: ${{ github.event_name }} • Workflow: ${{ github.event.workflow_run.name || 'scheduled-check' }}" }'
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -1,0 +1,23 @@
+name: Daily Summary
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+      timezone: America/Argentina/Buenos_Aires
+
+jobs:
+  summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build summary payload
+        id: payload
+        run: |
+          TEXT="Resumen diario IOpeer: builds, merges y runs fallidas pendiente de implementar."
+          echo "text=$TEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Post to Slack (placeholder)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          payload="{ \"text\": \"${{ steps.payload.outputs.text }}\" }"
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace
+        run: pnpm build
+
+      - name: Generate Prisma client
+        run: pnpm --dir apps/api prisma:generate
+
+      - name: Deploy to Vercel (placeholder)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          echo "Triggering Vercel deploy with pnpm dlx vercel (configure project/ORG IDs)."
+          pnpm dlx vercel deploy --prod --token "$VERCEL_TOKEN" --yes || echo "TODO: reemplazar con comando final"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,24 @@
+name: Promote Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Ambiente de destino"
+        required: false
+        default: production
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Promote canary
+        env:
+          PROMOTE_API_TOKEN: ${{ secrets.PROMOTE_API_TOKEN }}
+        run: |
+          TARGET="${{ github.event.inputs.target || 'production' }}"
+          echo "Promoting canary to ${TARGET} (placeholder)."
+          echo "Usar PROMOTE_API_TOKEN para llamar a la API real."

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,27 @@
+name: Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Motivo del rollback"
+        required: false
+  workflow_call:
+    inputs:
+      reason:
+        required: false
+        type: string
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ejecutar rollback (placeholder)
+        env:
+          ROLLBACK_TOKEN: ${{ secrets.ROLLBACK_TOKEN }}
+        run: |
+          echo "Rollback solicitado. Motivo: ${{ inputs.reason || github.event.inputs.reason || 'no especificado' }}"
+          echo "TODO: reemplazar por llamada a script/API real usando ROLLBACK_TOKEN"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "prisma:generate": "prisma generate --schema=prisma/schema.prisma",
-    "prisma:migrate": "prisma migrate dev --schema=prisma/schema.prisma",
+    "prisma:migrate": "prisma migrate dev --schema=prisma/schema.prisma -n core_models",
     "log:progress": "node scripts/log-progress.js",
     "log:progress:msg": "node scripts/log-progress.js --msg",
     "prettier": "prettier",
@@ -32,6 +32,8 @@
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.16.3",
     "pg": "^8.16.3",
+    "pino": "^9.6.0",
+    "pino-http": "^10.5.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/apps/api/prisma/migrations/20251005152715_core_models/migration.sql
+++ b/apps/api/prisma/migrations/20251005152715_core_models/migration.sql
@@ -1,5 +1,5 @@
 -- CreateEnum
-CREATE TYPE "RunStatus" AS ENUM ('PENDING', 'RUNNING', 'SUCCESS', 'FAILED', 'CANCELLED');
+CREATE TYPE "RunStatus" AS ENUM ('QUEUED', 'RUNNING', 'SUCCEEDED', 'FAILED', 'CANCELLED');
 
 -- CreateTable
 CREATE TABLE "User" (
@@ -49,7 +49,7 @@ CREATE TABLE "Workflow" (
 CREATE TABLE "Run" (
     "id" TEXT NOT NULL,
     "workflowId" TEXT NOT NULL,
-    "status" "RunStatus" NOT NULL DEFAULT 'PENDING',
+    "status" "RunStatus" NOT NULL DEFAULT 'QUEUED',
     "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "finishedAt" TIMESTAMP(3),
     "log" JSONB,

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -28,7 +28,7 @@ model Connection {
   id         String   @id @default(cuid())
   type       String              // e.g. "gmail", "slack", "http", "openai"
   name       String
-  config     Json                // tokens, creds encriptados (KMS)
+  config     Json                // TODO: cifrar config con KMS o secret manager
   createdAt  DateTime @default(now())
   userId     String
   user       User     @relation(fields: [userId], references: [id])
@@ -50,16 +50,16 @@ model Run {
   id         String   @id @default(cuid())
   workflowId String
   workflow   Workflow @relation(fields: [workflowId], references: [id])
-  status     RunStatus @default(PENDING)
+  status     RunStatus @default(QUEUED)
   startedAt  DateTime  @default(now())
   finishedAt DateTime?
   log        Json?                 // eventos/errores/output
 }
 
 enum RunStatus {
-  PENDING
+  QUEUED
   RUNNING
-  SUCCESS
+  SUCCEEDED
   FAILED
   CANCELLED
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,10 +10,11 @@ import { GateService } from './gates/gate.service';
 import { SchedulerService } from './scheduler/scheduler.service';
 import { HealthController } from './health/health.controller';
 import { SchedulerController } from './scheduler/scheduler.controller';
+import { MetricsController } from './metrics/metrics.controller';
 
 @Module({
   imports: [],
-  controllers: [RunsController, HealthController, SchedulerController],
+  controllers: [RunsController, HealthController, SchedulerController, MetricsController],
   providers: [
     PrismaClient,
     RunsService,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,10 +1,27 @@
-import { NestFactory } from "@nestjs/core";
-import { AppModule } from "./app.module";
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { LoggerMiddleware } from './middleware/logger.middleware';
+import { SchedulerService } from './scheduler/scheduler.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const loggerMiddleware = new LoggerMiddleware();
+  app.use(loggerMiddleware.use.bind(loggerMiddleware));
   app.enableCors();
-  await app.listen(process.env.PORT || 4000);
+  const port = Number(process.env.PORT ?? 3001);
+  await app.listen(port, '0.0.0.0');
+
+  const scheduler = app.get(SchedulerService);
+  const interval = Number(process.env.SCHEDULER_INTERVAL_MS ?? 60_000);
+  setInterval(() => {
+    scheduler
+      .tick()
+      .catch((error) =>
+        // eslint-disable-next-line no-console
+        console.error('Scheduler tick failed', error),
+      );
+  }, interval);
+
   // eslint-disable-next-line no-console
   console.log(`API up on ${await app.getUrl()}`);
 }

--- a/apps/api/src/metrics/metrics.controller.ts
+++ b/apps/api/src/metrics/metrics.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get } from '@nestjs/common';
+import { PrismaClient, Prisma } from '@prisma/client';
+
+@Controller('metrics')
+export class MetricsController {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  @Get()
+  async getMetrics() {
+    const [runsTotal, runsFailed] = await Promise.all([
+      this.prisma.run.count(),
+      this.prisma.run.count({ where: { status: Prisma.RunStatus.FAILED } }),
+    ]);
+
+    const uptimeSec = Math.floor(process.uptime());
+    const errorRatePct = runsTotal > 0 ? (runsFailed / runsTotal) * 100 : 0;
+
+    return {
+      uptimeSec,
+      runsTotal,
+      runsFailed,
+      p95Ms: null, // TODO: capture latency percentiles once metrics pipeline is ready
+      p99Ms: null, // TODO: capture latency percentiles once metrics pipeline is ready
+      errorRatePct,
+    };
+  }
+}

--- a/apps/api/src/middleware/logger.middleware.ts
+++ b/apps/api/src/middleware/logger.middleware.ts
@@ -1,0 +1,63 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import pino from 'pino';
+import pinoHttp from 'pino-http';
+import { randomUUID } from 'node:crypto';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  private readonly logger = pino({
+    level: process.env.LOG_LEVEL ?? 'info',
+  });
+
+  private readonly httpLogger = pinoHttp({
+    logger: this.logger,
+    genReqId: (req, res) => {
+      const existing = req.headers['x-request-id'];
+      if (typeof existing === 'string' && existing.length > 0) {
+        res.setHeader('x-request-id', existing);
+        return existing;
+      }
+      const id = randomUUID();
+      res.setHeader('x-request-id', id);
+      return id;
+    },
+    customSuccessMessage: (req, res) =>
+      `request:complete ${req.method} ${req.url} ${res.statusCode}`,
+    customErrorMessage: (req, res, err) =>
+      `request:error ${req.method} ${req.url} ${res.statusCode} ${err?.message ?? ''}`,
+  });
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const start = Date.now();
+    const requestId =
+      (req.headers['x-request-id'] as string | undefined) ?? randomUUID();
+    req.headers['x-request-id'] = requestId;
+    res.setHeader('x-request-id', requestId);
+
+    this.logger.info(
+      {
+        requestId,
+        method: req.method,
+        url: req.originalUrl ?? req.url,
+      },
+      'request:start',
+    );
+
+    this.httpLogger(req, res);
+
+    res.on('finish', () => {
+      const durationMs = Date.now() - start;
+      this.logger.info(
+        {
+          requestId,
+          statusCode: res.statusCode,
+          durationMs,
+        },
+        'request:finish',
+      );
+    });
+
+    next();
+  }
+}

--- a/apps/api/src/runs/runs.controller.ts
+++ b/apps/api/src/runs/runs.controller.ts
@@ -15,6 +15,11 @@ export class RunsController {
     return this.runs.createRun(body.workflowId, body.nodes, body.meta);
   }
 
+  @Get('runs')
+  list() {
+    return this.runs.listRecentRuns(50);
+  }
+
   @Get('runs/:id')
   get(@Param('id') id: string) {
     return this.runs.getRun(id);

--- a/apps/api/src/runs/runs.service.ts
+++ b/apps/api/src/runs/runs.service.ts
@@ -1,12 +1,34 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { PrismaClient, Prisma, $Enums } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { StepsRegistry } from '../steps/registry';
+
+const MAX_ATTEMPTS = 3;
+const BASE_BACKOFF_MS = 2_000;
 
 type QueueItem = {
   runId: string;
   workflowId: string;
   nodes: any[];
-  meta?: any;
+  meta?: Record<string, any>;
+  attempt: number;
+};
+
+type RunLog = {
+  meta?: Record<string, any>;
+  attempts: number;
+  maxAttempts: number;
+  nextAttemptAt: string | null;
+  stepLogs: Array<{
+    id: string;
+    type: string;
+    startedAt: string;
+    finishedAt?: string;
+    durationMs?: number;
+    status: 'OK' | 'ERROR';
+    output?: unknown;
+    error?: string;
+  }>;
+  error?: string;
 };
 
 @Injectable()
@@ -16,20 +38,35 @@ export class RunsService {
   private processing = false;
 
   constructor(
-    private prisma: PrismaClient,
-    private steps: StepsRegistry,
+    private readonly prisma: PrismaClient,
+    private readonly steps: StepsRegistry,
   ) {}
 
   async createRun(workflowId: string, nodes: any[], meta?: any) {
+    const log: RunLog = {
+      meta: meta ? { ...meta } : {},
+      attempts: 0,
+      maxAttempts: MAX_ATTEMPTS,
+      nextAttemptAt: null,
+      stepLogs: [],
+    };
+
     const run = await this.prisma.run.create({
       data: {
         workflowId,
-        status: $Enums.RunStatus.PENDING,
-        log: { meta } as any,
+        status: Prisma.RunStatus.QUEUED,
+        log: log as any,
       },
     });
-    this.queue.push({ runId: run.id, workflowId, nodes, meta });
-    this.processNext().catch((e) => this.logger.error(e));
+
+    this.enqueue({
+      runId: run.id,
+      workflowId,
+      nodes,
+      meta,
+      attempt: 0,
+    });
+
     return run;
   }
 
@@ -37,44 +74,212 @@ export class RunsService {
     return this.prisma.run.findUnique({ where: { id } });
   }
 
-  private async processNext() {
-    if (this.processing || this.queue.length === 0) return;
+  async listRecentRuns(limit = 50) {
+    return this.prisma.run.findMany({
+      orderBy: { startedAt: 'desc' },
+      take: limit,
+    });
+  }
+
+  private enqueue(job: QueueItem, delayMs = 0) {
+    if (delayMs > 0) {
+      setTimeout(() => {
+        this.queue.push(job);
+        this.processNext().catch((error) => this.logger.error(error));
+      }, delayMs);
+      return;
+    }
+
+    this.queue.push(job);
+    this.processNext().catch((error) => this.logger.error(error));
+  }
+
+  private async processNext(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
+
+    const job = this.queue.shift();
+    if (!job) {
+      return;
+    }
+
     this.processing = true;
 
-    const job = this.queue.shift()!;
     try {
-      await this.prisma.run.update({
-        where: { id: job.runId },
-        data: { status: RunStatus.RUNNING, startedAt: new Date() },
-      });
-
-      const stepLogs: any[] = [];
-      for (const node of job.nodes) {
-        const step = this.steps.get(node.type);
-        const out = await step.run(node.params || {});
-        stepLogs.push({ id: node.id, type: node.type, output: out });
-        await this.prisma.run.update({
-          where: { id: job.runId },
-          data: { log: { stepLogs } as any },
-        });
+      const run = await this.prisma.run.findUnique({ where: { id: job.runId } });
+      if (!run) {
+        return;
       }
 
-      await this.prisma.run.update({
-        where: { id: job.runId },
-        data: { status: $Enums.RunStatus.SUCCESS, finishedAt: new Date() },
-      });
-    } catch (err: any) {
+      const previousLog = ((run.log as RunLog | null) ?? {
+        attempts: 0,
+        maxAttempts: MAX_ATTEMPTS,
+        nextAttemptAt: null,
+        stepLogs: [],
+      }) as RunLog;
+
+      const stepLogs = Array.isArray(previousLog.stepLogs)
+        ? [...previousLog.stepLogs]
+        : [];
+
+      const currentLog: RunLog = {
+        ...previousLog,
+        meta: {
+          ...(previousLog.meta ?? {}),
+          ...(job.meta ?? {}),
+        },
+        attempts: previousLog.attempts ?? 0,
+        maxAttempts: previousLog.maxAttempts ?? MAX_ATTEMPTS,
+        nextAttemptAt: null,
+        stepLogs,
+      };
+      if ('error' in currentLog) {
+        delete (currentLog as Partial<RunLog>).error;
+      }
+
+      const startedAt = run.startedAt ?? new Date();
+
       await this.prisma.run.update({
         where: { id: job.runId },
         data: {
-          status: RunStatus.FAILED,
-          finishedAt: new Date(),
-          log: { error: String(err?.message ?? err) } as any,
+          status: Prisma.RunStatus.RUNNING,
+          startedAt,
+          log: currentLog as any,
         },
       });
+
+      for (const node of job.nodes) {
+        const step = this.steps.get(node.type);
+        const stepStart = new Date();
+        const stepLogBase = {
+          id: String(node.id ?? node.type),
+          type: String(node.type),
+          startedAt: stepStart.toISOString(),
+        };
+
+        try {
+          const output = await step.run(node.params ?? {});
+          const finishedAt = new Date();
+          const entry = {
+            ...stepLogBase,
+            finishedAt: finishedAt.toISOString(),
+            durationMs: finishedAt.getTime() - stepStart.getTime(),
+            status: 'OK' as const,
+            ...(output !== undefined ? { output } : {}),
+          };
+          currentLog.stepLogs = [...currentLog.stepLogs, entry];
+          await this.prisma.run.update({
+            where: { id: job.runId },
+            data: {
+              log: currentLog as any,
+            },
+          });
+        } catch (stepError: any) {
+          const finishedAt = new Date();
+          const entry = {
+            ...stepLogBase,
+            finishedAt: finishedAt.toISOString(),
+            durationMs: finishedAt.getTime() - stepStart.getTime(),
+            status: 'ERROR' as const,
+            error: stepError?.message ?? String(stepError),
+          };
+          currentLog.stepLogs = [...currentLog.stepLogs, entry];
+          currentLog.error = stepError?.message ?? String(stepError);
+
+          await this.prisma.run.update({
+            where: { id: job.runId },
+            data: {
+              log: currentLog as any,
+            },
+          });
+
+          throw stepError;
+        }
+      }
+
+     await this.prisma.run.update({
+        where: { id: job.runId },
+        data: {
+          status: Prisma.RunStatus.SUCCEEDED,
+          finishedAt: new Date(),
+          log: currentLog as any,
+        },
+      });
+    } catch (error: any) {
+      await this.handleRunFailure(job, error);
     } finally {
       this.processing = false;
-      this.processNext().catch(() => {});
+      if (this.queue.length > 0) {
+        this.processNext().catch((err) => this.logger.error(err));
+      }
     }
+  }
+
+  private async handleRunFailure(job: QueueItem, error: any) {
+    const run = await this.prisma.run.findUnique({ where: { id: job.runId } });
+    if (!run) {
+      return;
+    }
+
+    const currentLog: RunLog = {
+      attempts: 0,
+      maxAttempts: MAX_ATTEMPTS,
+      nextAttemptAt: null,
+      stepLogs: [],
+      ...(run.log as RunLog | null),
+    };
+    currentLog.meta = currentLog.meta ?? {};
+    currentLog.stepLogs = Array.isArray(currentLog.stepLogs)
+      ? currentLog.stepLogs
+      : [];
+
+    const attempts = (currentLog.attempts ?? 0) + 1;
+    const maxAttempts = currentLog.maxAttempts ?? MAX_ATTEMPTS;
+    currentLog.attempts = attempts;
+    currentLog.maxAttempts = maxAttempts;
+    currentLog.error = error?.message ?? String(error);
+
+    if (attempts < maxAttempts) {
+      const delay = BASE_BACKOFF_MS * Math.pow(2, attempts);
+      const nextAttemptAt = new Date(Date.now() + delay);
+      currentLog.nextAttemptAt = nextAttemptAt.toISOString();
+
+      await this.prisma.run.update({
+        where: { id: job.runId },
+        data: {
+          status: Prisma.RunStatus.QUEUED,
+          log: currentLog as any,
+        },
+      });
+
+      this.logger.warn(
+        `Run ${job.runId} failed (attempt ${attempts}/${maxAttempts}). Retrying in ${delay}ms`,
+      );
+
+      this.enqueue(
+        {
+          ...job,
+          attempt: attempts,
+        },
+        delay,
+      );
+      return;
+    }
+
+    currentLog.nextAttemptAt = null;
+
+    await this.prisma.run.update({
+      where: { id: job.runId },
+      data: {
+        status: Prisma.RunStatus.FAILED,
+        finishedAt: new Date(),
+        log: currentLog as any,
+      },
+    });
+
+    this.logger.error(
+      `Run ${job.runId} failed permanently after ${attempts} attempts: ${currentLog.error}`,
+    );
   }
 }

--- a/apps/api/src/scheduler/scheduler.service.ts
+++ b/apps/api/src/scheduler/scheduler.service.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { RunsService } from '../runs/runs.service';
 import { GateService } from '../gates/gate.service';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 
 @Injectable()
 export class SchedulerService {
@@ -34,7 +34,7 @@ export class SchedulerService {
     // 1) calcular qué acciones ya “SUCCEEDED” mirando logs (simple)
     const succeeded: Record<string, string> = {};
     const finished = await this.prisma.run.findMany({
-      where: { status: { equals: $Enums.RunStatus.SUCCESS } },
+      where: { status: { equals: Prisma.RunStatus.SUCCEEDED } },
     });
     for (const r of finished) {
       const actionId = (r.log as any)?.meta?.actionId;

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "vitest.config.ts"]
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -21,5 +21,6 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "exclude": ["node_modules", "dist", "test", "vitest.config.ts"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/auth-helpers-nextjs": "^0.10.2",
     "@supabase/supabase-js": "^2.58.0",
+    "@supabase/ssr": "^0.5.2",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+
+type Run = {
+  id: string;
+  workflowId: string;
+  status: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+};
+
+export default function DashboardPage() {
+  const apiBase = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRuns = useCallback(async () => {
+    try {
+      const response = await fetch(`${apiBase}/runs`, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Error ${response.status}`);
+      }
+      const data: Run[] = await response.json();
+      setRuns(data);
+      setError(null);
+    } catch (err: any) {
+      setError(err?.message ?? 'No se pudo cargar la lista de runs');
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBase]);
+
+  useEffect(() => {
+    loadRuns();
+    const interval = setInterval(loadRuns, 5_000);
+    return () => clearInterval(interval);
+  }, [loadRuns]);
+
+  const hasRuns = runs.length > 0;
+
+  const content = useMemo(() => {
+    if (loading && !hasRuns) {
+      return <p className="text-sm text-gray-500">Cargando runs…</p>;
+    }
+
+    if (error && !hasRuns) {
+      return <p className="text-sm text-red-600">{error}</p>;
+    }
+
+    if (!hasRuns) {
+      return <p className="text-sm text-gray-500">No hay runs recientes.</p>;
+    }
+
+    return (
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Run ID
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Workflow
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Status
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Inicio
+              </th>
+              <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Fin
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {runs.map((run) => (
+              <tr key={run.id} className="hover:bg-gray-50">
+                <td className="px-4 py-2 text-sm font-medium text-blue-600">
+                  <Link href={`/dashboard/runs/${run.id}`}>{run.id}</Link>
+                </td>
+                <td className="px-4 py-2 text-sm text-gray-700">{run.workflowId}</td>
+                <td className="px-4 py-2 text-sm text-gray-700">
+                  <StatusPill status={run.status} />
+                </td>
+                <td className="px-4 py-2 text-sm text-gray-700">{formatDate(run.startedAt)}</td>
+                <td className="px-4 py-2 text-sm text-gray-700">{formatDate(run.finishedAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }, [error, hasRuns, loading, runs]);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Dashboard de Runs</h1>
+        <p className="text-sm text-gray-500">
+          Polling cada 5 segundos desde {apiBase}/runs. Ajustá NEXT_PUBLIC_API_URL para ambientes
+          remotos.
+        </p>
+        {error && hasRuns && (
+          <p className="text-sm text-red-600">Último error de polling: {error}</p>
+        )}
+      </header>
+      {content}
+    </main>
+  );
+}
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function StatusPill({ status }: { status: string }) {
+  const normalized = status?.toUpperCase?.() ?? '';
+  const color = getStatusColor(normalized);
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${color}`}
+    >
+      {normalized || '—'}
+    </span>
+  );
+}
+
+function getStatusColor(status: string) {
+  switch (status) {
+    case 'SUCCEEDED':
+      return 'bg-emerald-100 text-emerald-700';
+    case 'RUNNING':
+      return 'bg-blue-100 text-blue-700';
+    case 'FAILED':
+      return 'bg-red-100 text-red-700';
+    case 'QUEUED':
+      return 'bg-amber-100 text-amber-700';
+    default:
+      return 'bg-gray-100 text-gray-600';
+  }
+}

--- a/apps/web/src/app/dashboard/runs/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/runs/[id]/page.tsx
@@ -1,0 +1,185 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+type RunResponse = {
+  id: string;
+  workflowId: string;
+  status: string;
+  log?: {
+    meta?: Record<string, unknown>;
+    attempts?: number;
+    maxAttempts?: number;
+    nextAttemptAt?: string | null;
+    error?: string;
+    stepLogs?: StepLog[];
+  };
+  startedAt: string | null;
+  finishedAt: string | null;
+};
+
+type StepLog = {
+  id: string;
+  type: string;
+  startedAt: string;
+  finishedAt?: string;
+  durationMs?: number;
+  status: 'OK' | 'ERROR';
+  output?: unknown;
+  error?: string;
+};
+
+export default async function RunDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const response = await fetch(`${API_BASE}/runs/${params.id}`, {
+    cache: 'no-store',
+  });
+
+  if (response.status === 404) {
+    notFound();
+  }
+
+  if (!response.ok) {
+    throw new Error(`Error al obtener el run ${params.id}`);
+  }
+
+  const run = (await response.json()) as RunResponse;
+  const stepLogs = Array.isArray(run.log?.stepLogs) ? run.log?.stepLogs ?? [] : [];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-6 p-6">
+      <Link href="/dashboard" className="text-sm text-blue-600">
+        ← Volver al dashboard
+      </Link>
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Run {run.id}</h1>
+        <p className="text-sm text-gray-500">
+          Workflow {run.workflowId} — Estado {run.status}
+        </p>
+        <dl className="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
+          <div>
+            <dt className="font-medium text-gray-500">Intentos</dt>
+            <dd>
+              {run.log?.attempts ?? 0} / {run.log?.maxAttempts ?? '—'}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">Próximo intento</dt>
+            <dd>{formatDate(run.log?.nextAttemptAt)}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">Inicio</dt>
+            <dd>{formatDate(run.startedAt)}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">Fin</dt>
+            <dd>{formatDate(run.finishedAt)}</dd>
+          </div>
+        </dl>
+      </header>
+
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Metadatos</h2>
+        <pre className="overflow-x-auto rounded border border-gray-200 bg-gray-50 p-4 text-sm">
+          {JSON.stringify(run.log?.meta ?? {}, null, 2)}
+        </pre>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Step Logs</h2>
+        {stepLogs.length === 0 ? (
+          <p className="text-sm text-gray-500">Sin registros de pasos todavía.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Nodo
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Tipo
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Estado
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Inicio
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Fin
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Duración (ms)
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Output / Error
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {stepLogs.map((log) => (
+                  <tr key={`${log.id}-${log.startedAt}`} className="align-top">
+                    <td className="px-4 py-2 text-sm font-medium text-gray-700">{log.id}</td>
+                    <td className="px-4 py-2 text-sm text-gray-700">{log.type}</td>
+                    <td className="px-4 py-2 text-sm text-gray-700">{log.status}</td>
+                    <td className="px-4 py-2 text-sm text-gray-700">{formatDate(log.startedAt)}</td>
+                    <td className="px-4 py-2 text-sm text-gray-700">{formatDate(log.finishedAt)}</td>
+                    <td className="px-4 py-2 text-sm text-gray-700">{log.durationMs ?? '—'}</td>
+                    <td className="px-4 py-2 text-sm text-gray-700">
+                      {log.status === 'OK' ? (
+                        <pre className="max-h-32 overflow-auto rounded bg-gray-50 p-2">
+                          {formatOutput(log.output)}
+                        </pre>
+                      ) : (
+                        <span className="text-red-600">{log.error ?? 'Error desconocido'}</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {run.log?.error && (
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold text-red-600">Último error</h2>
+          <p className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {run.log.error}
+          </p>
+        </section>
+      )}
+    </main>
+  );
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function formatOutput(value: unknown) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (error) {
+    return String(value);
+  }
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { SupabaseProvider } from "./supabase-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+        <SupabaseProvider>{children}</SupabaseProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useSupabase } from '../supabase-provider';
+
+export default function LoginPage() {
+  const supabase = useSupabase();
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'sent' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus('loading');
+    setMessage('');
+
+    const redirectTo =
+      process.env.NEXT_PUBLIC_SUPABASE_REDIRECT ?? 'http://localhost:3000/dashboard';
+
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: redirectTo,
+      },
+    });
+
+    if (error) {
+      setStatus('error');
+      setMessage(error.message);
+      return;
+    }
+
+    setStatus('sent');
+    setMessage('Revisá tu email para el Magic Link.');
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col justify-center gap-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold">Iniciar sesión</h1>
+        <p className="text-sm text-gray-500">
+          Usamos Magic Links de Supabase. Configurá las variables NEXT_PUBLIC_SUPABASE_URL y
+          NEXT_PUBLIC_SUPABASE_ANON_KEY en tu entorno local.
+        </p>
+      </div>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Email</span>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="rounded border border-gray-300 p-2"
+            placeholder="usuario@example.com"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={status === 'loading'}
+          className="w-full rounded bg-black px-4 py-2 font-medium text-white disabled:opacity-50"
+        >
+          {status === 'loading' ? 'Enviando…' : 'Enviar Magic Link'}
+        </button>
+      </form>
+      {message && (
+        <p className={status === 'error' ? 'text-sm text-red-600' : 'text-sm text-emerald-600'}>
+          {message}
+        </p>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/supabase-provider.tsx
+++ b/apps/web/src/app/supabase-provider.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createBrowserClient } from '@supabase/ssr';
+
+type SupabaseContextValue = SupabaseClient;
+
+const SupabaseContext = createContext<SupabaseContextValue | null>(null);
+
+function createClient() {
+  const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://placeholder.supabase.co';
+  const supabaseAnonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? 'public-anon-key';
+
+  return createBrowserClient(supabaseUrl, supabaseAnonKey);
+}
+
+export function SupabaseProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [client] = useState(() => createClient());
+  const value = useMemo(() => client, [client]);
+
+  return <SupabaseContext.Provider value={value}>{children}</SupabaseContext.Provider>;
+}
+
+export function useSupabase() {
+  const client = useContext(SupabaseContext);
+  if (!client) {
+    throw new Error('Supabase client is not available.');
+  }
+  return client;
+}

--- a/docs/security-rotation.md
+++ b/docs/security-rotation.md
@@ -1,0 +1,40 @@
+# 🔐 Checklist de rotación de credenciales IOpeer
+
+> Referencia operativa para rotar secretos sin comprometer ambientes. No almacenar llaves reales en el repositorio; usar `.env.local`, `env.example` o gestores de secretos externos.
+
+## Frecuencia sugerida
+- 🔄 **Mensual**: claves Supabase (anon/service role) y tokens Slack.
+- 🔄 **Trimestral**: credenciales OAuth (Gmail) y tokens de despliegue (Vercel, GitHub PAT).
+- 🔄 **Ante incidente**: cualquier exposición o alerta de seguridad.
+
+## Pasos generales
+1. Inventariar secretos activos y validar responsables.
+2. Generar nuevas credenciales en el proveedor correspondiente.
+3. Actualizar `env.example` con placeholders representativos (sin credenciales reales).
+4. Rotar valores en los entornos gestionados (Supabase, Vercel, GitHub Actions, Slack, etc.).
+5. Invalidar las claves anteriores y documentar fecha/hora de cambio.
+6. Ejecutar smoke tests y monitorear métricas/alertas durante al menos 30 minutos.
+
+## Elementos a rotar
+- Supabase: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE`.
+- Gmail OAuth: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REFRESH_TOKEN`.
+- Slack: `SLACK_WEBHOOK_URL`, tokens de bots y apps internas.
+- Vercel: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
+- GitHub: PAT para CI/CD y automatizaciones (`ACTIONS_DEPLOY_TOKEN`, etc.).
+
+## Buenas prácticas
+- Documentar el responsable y la fecha de la última rotación en un registro interno.
+- Usar un gestor centralizado (1Password, Vault, Doppler, etc.) para distribuir secretos.
+- Implementar alertas sobre accesos inusuales o uso de llaves revocadas.
+- Mantener `env.example` como fuente de verdad de variables esperadas.
+- Validar que ninguna credencial queda en logs, commits o archivos temporales.
+
+## Connection.secret_ref
+- Los modelos `Connection` deben almacenar referencias (`secret_ref`) que se resuelven en el servidor desde `process.env` o un KV seguro.
+- **No** persistir secretos planos en la base de datos.
+- TODO: evaluar cifrado en reposo/`KMS` para futuras iteraciones.
+
+## Post-rotación
+- Notificar al equipo por el canal de seguridad.
+- Registrar incidencias o aprendizajes en el runbook.
+- Programar la próxima revisión automática (cron, ticket, etc.).

--- a/docs/workflow-flow.md
+++ b/docs/workflow-flow.md
@@ -1,0 +1,193 @@
+# 📘 IOpeer Workflow Flow Documentation
+
+## 🧭 Visión general
+Los **workflows de IOpeer** siguen una estructura ascendente y segura. Cada nivel (L1–L5) representa un grado mayor de complejidad y madurez del sistema. El **Scheduler** se encarga de ejecutar las acciones en orden ascendente, garantizando que las dependencias se cumplan antes de avanzar.
+
+---
+
+## 🧩 Diagrama de flujo general
+
+```mermaid
+flowchart TD
+  subgraph Inputs
+    A[Backlog Técnico] -->|prioridad/complexidad| B[Cronograma Ascendente]
+    C[Eventos (Webhooks/Manuales)] --> B
+  end
+
+  subgraph Planificación
+    B --> D[Scheduler (Cron/Interval)]
+    D --> E[Selector de Próxima Acción (L1→L5)]
+    E --> F{Gates de Seguridad<br/>y Prerrequisitos}
+    F -->|OK| G[Enqueue Run (Queue in-memory)]
+    F -->|Falla| F1[Reprogramar/Registrar bloqueo]
+  end
+
+  subgraph Ejecución
+    G --> H[Resolver Secrets (secret_ref→env/KV)]
+    H --> I[Sandbox de Ejecución<br/>(Step Runner)]
+    I --> J[Logs por Paso + Métricas]
+    I --> K{Resultado}
+    K -->|Success| L[Persistir Run: SUCCEEDED]
+    K -->|Error| M[Retry con Backoff]
+    M -->|Max Retries| N[Persistir Run: FAILED]
+    M -->|Aún hay retries| G
+  end
+
+  subgraph Promoción y Despliegue
+    L --> O{Gate de Calidad/SLO<br/>Tests e2e, p95/p99, error_rate}
+    O -->|OK x 60min| P[Promote canary→prod]
+    O -->|No OK| Q[Hold + Alertas Slack]
+    P --> R[Deploy estable]
+  end
+
+  subgraph Observabilidad
+    J --> S[Logs estructurados (Pino)]
+    J --> T[Métricas (/metrics)]
+    L --> U[Alertas éxito (Slack)]
+    N --> V[Alertas fallo (Slack + email)]
+  end
+```
+
+---
+
+## 🔁 Secuencia de ejecución (una acción ascendente)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CR as Cronograma
+  participant SCH as Scheduler
+  participant Q as Queue
+  participant SEC as Secrets Resolver
+  participant EX as Step Runner
+  participant DB as Prisma(DB)
+  participant OBS as Observabilidad
+
+  CR->>SCH: nextAction(level=L1)
+  SCH->>SCH: verificar prerrequisitos (Gates)
+  SCH->>Q: enqueue(run:{workflowId, actionId})
+  Q-->>EX: dequeue()
+  EX->>SEC: resolve(secret_ref)
+  SEC-->>EX: creds temporales
+  EX->>DB: crear Run(status=RUNNING)
+  EX->>EX: ejecutar nodos (echo/delay/http/if)
+  EX->>OBS: enviar logs y métricas por paso
+  EX-->>DB: actualizar Run(status=SUCCEEDED/FAILED)
+  alt success
+    DB-->>SCH: resultado OK
+    SCH->>CR: marcar acción L1 done
+    SCH->>SCH: habilitar L2 (promoción)
+  else error
+    SCH->>Q: retry backoff (hasta max_retries)
+    Q-->>EX: reintentar
+  end
+```
+
+---
+
+## 📈 Cronograma ascendente — Niveles
+
+| Nivel | Descripción | Ejemplo de tareas |
+|-------|--------------|-------------------|
+| L1 | Fundacional | Health API, configuración base, hook Supabase Auth |
+| L2 | Persistencia | Prisma modelos `Connection`, `Run`, migraciones |
+| L3 | Ejecución | Cola in-memory, `RunsController`, nodos básicos |
+| L4 | Calidad y observabilidad | Tests, logs, métricas p95/p99 |
+| L5 | Entrega | Deploy canary → prod, rollback automático |
+
+---
+
+## 🧠 Ejemplo DSL del plan (JSON)
+
+```json
+{
+  "plan": "iopeer-bootstrap",
+  "policy": {
+    "order": "ascending",
+    "retry": { "max": 3, "strategy": "exponential", "baseMs": 2000 },
+    "gates": {
+      "L2_requires": ["L1"],
+      "L3_requires": ["L2"],
+      "L4_requires": ["L3"],
+      "L5_requires": ["L4"]
+    },
+    "promote": { "windowMinutes": 60, "slo": { "errorRatePct": 1, "p95Ms": 600 } }
+  },
+  "schedule": [
+    {
+      "id": "L1-HEALTH",
+      "level": "L1",
+      "workflowId": "wf.health",
+      "pre": ["env:API_PORT", "db:reachable"],
+      "nodes": [
+        { "id": "n1", "type": "echo", "params": { "message": "Boot L1" } },
+        { "id": "n2", "type": "http", "params": { "url": "http://api:3001/health" } }
+      ]
+    },
+    {
+      "id": "L2-PRISMA",
+      "level": "L2",
+      "workflowId": "wf.prisma.migrate",
+      "pre": ["L1-HEALTH:SUCCEEDED"],
+      "nodes": [
+        { "id": "n1", "type": "echo", "params": { "message": "Migrating DB" } },
+        { "id": "n2", "type": "shell", "params": { "cmd": "pnpm -C apps/api prisma migrate deploy" } }
+      ]
+    },
+    {
+      "id": "L3-RUNNER",
+      "level": "L3",
+      "workflowId": "wf.runner.basic",
+      "pre": ["L2-PRISMA:SUCCEEDED"],
+      "nodes": [
+        { "id": "n1", "type": "delay", "params": { "ms": 500 } },
+        { "id": "n2", "type": "echo", "params": { "message": "Queue up" } },
+        { "id": "n3", "type": "http", "params": { "url": "http://api:3001/runs/test" } }
+      ]
+    },
+    {
+      "id": "L4-QUALITY",
+      "level": "L4",
+      "workflowId": "wf.quality",
+      "pre": ["L3-RUNNER:SUCCEEDED"],
+      "nodes": [
+        { "id": "n1", "type": "shell", "params": { "cmd": "pnpm -C apps/api test" } },
+        { "id": "n2", "type": "metrics.assert", "params": { "p95MsMax": 600, "errorRatePctMax": 1 } }
+      ]
+    },
+    {
+      "id": "L5-DELIVERY",
+      "level": "L5",
+      "workflowId": "wf.delivery",
+      "pre": ["L4-QUALITY:SUCCEEDED"],
+      "nodes": [
+        { "id": "n1", "type": "http", "params": { "url": "http://ci/canary/deploy", "method": "POST" } },
+        { "id": "n2", "type": "delay", "params": { "ms": 3600000 } },
+        { "id": "n3", "type": "slo.check", "params": { "windowMin": 60, "p95MsMax": 600, "errorRatePctMax": 1 } },
+        { "id": "n4", "type": "http", "params": { "url": "http://ci/promote", "method": "POST" } }
+      ],
+      "onFail": [
+        { "type": "http", "params": { "url": "http://ci/rollback", "method": "POST" } },
+        { "type": "slack.notify", "params": { "channel": "#iopeer-alerts", "message": "Rollback executed" } }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 🧠 Componentes técnicos involucrados
+
+- **SchedulerService** → lee el plan, valida dependencias y gates, y encola ejecuciones.
+- **RunsService** → maneja cola en memoria, ejecución de pasos y persistencia de resultados.
+- **GateService** → controla prerequisitos (env, DB, dependencias previas) y gates de calidad.
+- **StepRunner** → ejecuta nodos del DSL (echo, delay, http, shell, slack.notify, etc.).
+- **Connectors** → interfaz genérica para nuevos pasos o integraciones.
+- **ObservabilityService** → maneja logs estructurados, métricas y alertas.
+
+---
+
+## ✅ Propósito final
+Garantizar un flujo **ascendente, seguro y verificable**, donde IOpeer construya y despliegue sus propios componentes de manera autónoma, respetando gates de calidad y dependencias previas, hasta alcanzar una ejecución continua y estable.
+

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "iopeer",
   "private": true,
-  "packageManager": "pnpm@9",
+  "packageManager": "pnpm@9.0.0",
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",
     "prepare": "husky install",
+    "api:dev": "pnpm --dir apps/api start:dev",
+    "api:start": "pnpm --dir apps/api start",
+    "web:dev": "pnpm --dir apps/web dev",
     "log:progress": "node scripts/log-progress.js",
     "log:progress:msg": "node scripts/log-progress.js --msg"
   },


### PR DESCRIPTION
## Summary
- add exponential retry/backoff, richer step logging, and list endpoints to the runs service
- wire scheduler tick interval, structured request logging, and a /metrics controller for observability
- build minimal Supabase login, documentation page, run dashboards, and new CI/CD workflows with security rotation notes

## Testing
- `pnpm install` *(fails: proxy blocked downloading pnpm 9.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b292fe78832590b00f5dd2bc7949