### PR TITLE
fix(ci): remove unsupported pnpm action input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 9.15.9
-          run: pnpm install --frozen-lockfile
 
 
       - name: Setup Node


### PR DESCRIPTION
## Summary
- remove the unsupported `run` input from the pnpm setup step so the workflow no longer fails during setup

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2b7f4a1b483259d6c31150842460c