### PR TITLE
Fix Prisma client integration in API

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,5 @@
 /* c8 ignore file */
 import { Module } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -16,6 +15,7 @@ import { EchoStep } from './steps/echo';
 import { DelayStep } from './steps/delay';
 import { HttpStep } from './steps/http';
 import { PinoLoggerService } from './logger/pino-logger.service';
+import { PrismaService } from './prisma/prisma.service';
 
 @Module({
   imports: [],
@@ -27,7 +27,7 @@ import { PinoLoggerService } from './logger/pino-logger.service';
     MetricsController,
   ],
   providers: [
-    PrismaClient,
+    PrismaService,
     AppService,
     PinoLoggerService,
     RunsService,

--- a/apps/api/src/gates/gate.service.ts
+++ b/apps/api/src/gates/gate.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class GateService {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private prisma: PrismaService) {}
 
   async checkEnv(keys: string[]): Promise<boolean> {
     for (const k of keys) {

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+
+import { PrismaService } from '../prisma/prisma.service';
 
 @Controller('health')
 export class HealthController {
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   @Get()
   async get() {

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -1,0 +1,19 @@
+import { INestApplication, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    process.on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/apps/api/src/runs/runs.service.ts
+++ b/apps/api/src/runs/runs.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClient, Run, RunStatus, Prisma } from '@prisma/client';
+import { Prisma, Run, RunStatus } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
 import { rootLogger } from '../logger/pino-logger.service';
 import { StepsRegistry, type Step, type StepContext } from '../steps/registry';
+import { PrismaService } from '../prisma/prisma.service';
 
 export type StepNode = {
   id: string;
@@ -58,7 +59,7 @@ export class RunsService {
   };
 
   constructor(
-    private readonly prisma: PrismaClient,
+    private readonly prisma: PrismaService,
     private readonly stepsRegistry: StepsRegistry,
   ) {}
 


### PR DESCRIPTION
## Summary
- add a dedicated PrismaService wrapper for the Nest API
- update modules and services to consume the new PrismaService instead of raw PrismaClient
- ensure shutdown hooks use Node's beforeExit event without relying on deprecated Prisma client typings

## Testing
- Not run (network restrictions prevented installing dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68e2f8d85fec8325a284ed12cccdd0a5