### PR TITLE
Fix workflow ID typing in report service

### DIFF
--- a/apps/api/src/reports/report.service.ts
+++ b/apps/api/src/reports/report.service.ts
@@ -50,11 +50,11 @@ export class ReportService {
 
     const workflowIds = topWorkflows
       .map((t) => t.workflowId)
-      .filter((id): id is number => id != null);
+      .filter((id): id is string => id != null);
 
-    type WorkflowSummary = { id: number; key: string | null; name: string | null };
+    type WorkflowSummary = { id: string; key: string | null; name: string | null };
 
-    const workflowsMap = new Map<number, WorkflowSummary>(
+    const workflowsMap = new Map<string, WorkflowSummary>(
       (
         await this.prisma.workflow.findMany({
           where: { id: { in: workflowIds } },


### PR DESCRIPTION
## Summary
- update workflow report generation to treat workflow IDs as strings
- ensure workflow lookups use a string-keyed map to avoid type mismatches

## Testing
- `pnpm --filter api build` *(fails: missing optional dependencies like @nestjs/schedule and groq-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68e4541ae8908325a0036b055a0e6aca