### PR TITLE
Fix Prisma service imports in API AppModule

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,7 +9,7 @@ import { MetricsController } from './metrics/metrics.controller';
 import { SchedulerService } from './scheduler/scheduler.service';
 import { SchedulerController } from './scheduler/scheduler.controller';
 import { ScheduleModule } from '@nestjs/schedule';
-import { PrismaModule } from '../prisma/prisma.module';
+import { PrismaModule } from './prisma/prisma.module';
 import { ReportModule } from './reports/report.module';
 import { GateService } from './gates/gate.service';
 import { StepsRegistry } from './steps/registry';
@@ -17,7 +17,7 @@ import { EchoStep } from './steps/echo';
 import { DelayStep } from './steps/delay';
 import { HttpStep } from './steps/http';
 import { PinoLoggerService } from './logger/pino-logger.service';
-import { PrismaService } from '../prisma/prisma.service';
+import { PrismaService } from './prisma/prisma.service';
 
 @Module({
   imports: [PrismaModule, ScheduleModule.forRoot(), ReportModule],


### PR DESCRIPTION
## Summary
- update the AppModule to import PrismaModule and PrismaService from the shared src/prisma directory so dependency injection uses the same provider instance

## Testing
- pnpm start *(fails: missing optional dependencies such as @nestjs/schedule, groq-sdk, nodemailer, and Prisma types)*

------
https://chatgpt.com/codex/tasks/task_e_68e45570d61883258439b123ef211f1e