### PR TITLE
Align run status usage with Prisma schema

### DIFF
--- a/apps/api/src/gates/gate.service.ts
+++ b/apps/api/src/gates/gate.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PrismaService } from '../prisma/prisma.service';
+import { SUCCESS_VALUES } from '../runs/run-status';
 
 @Injectable()
 export class GateService {
@@ -23,7 +24,8 @@ export class GateService {
   }
 
   async checkDepsSucceeded(depResults: Record<string, string>): Promise<boolean> {
-    const successValues = new Set(['SUCCESS', 'SUCCEEDED']);
-    return Object.values(depResults).every((status) => successValues.has(status));
+    return Object.values(depResults).every(
+      (status) => typeof status === 'string' && SUCCESS_VALUES.has(status),
+    );
   }
 }

--- a/apps/api/src/metrics/metrics.controller.ts
+++ b/apps/api/src/metrics/metrics.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Optional } from '@nestjs/common';
-import { RunStatus } from '@prisma/client';
 
 import type { PrismaService } from '../prisma/prisma.service';
 import type { RunsService } from '../runs/runs.service';
+import { RUN_STATUS } from '../runs/run-status';
 
 type PrismaLike = Pick<PrismaService, 'run'>;
 type RunsLike = Pick<RunsService, 'getStats'>;
@@ -53,7 +53,7 @@ export class MetricsController {
       };
     }
 
-    const statusFailed = (RunStatus as any).ERROR ?? (RunStatus as any).FAILED ?? 'ERROR';
+    const statusFailed = RUN_STATUS.ERROR;
 
     const [total, failed] = await Promise.all([
       prisma.run.count(),

--- a/apps/api/src/runs/run-status.ts
+++ b/apps/api/src/runs/run-status.ts
@@ -1,0 +1,33 @@
+import { RunStatus } from '@prisma/client';
+
+type RunStatusRecord = Record<string, RunStatus>;
+
+const runStatusEnum = (RunStatus ?? {}) as RunStatusRecord;
+
+const statusFor = (primary: string, ...aliases: string[]) => {
+  if (runStatusEnum && primary in runStatusEnum) {
+    return runStatusEnum[primary];
+  }
+  for (const alias of aliases) {
+    if (runStatusEnum && alias in runStatusEnum) {
+      return runStatusEnum[alias];
+    }
+  }
+  return primary as unknown as RunStatus;
+};
+
+export const RUN_STATUS = {
+  PENDING: statusFor('PENDING', 'QUEUED'),
+  RUNNING: statusFor('RUNNING'),
+  SUCCESS: statusFor('SUCCESS', 'SUCCEEDED'),
+  ERROR: statusFor('ERROR', 'FAILED'),
+  CANCELLED: statusFor('CANCELLED'),
+} as const;
+
+export type ResolvedRunStatus = (typeof RUN_STATUS)[keyof typeof RUN_STATUS];
+
+export const SUCCESS_VALUES = new Set<string>([
+  RUN_STATUS.SUCCESS,
+  'SUCCESS',
+  'SUCCEEDED',
+]);

--- a/apps/api/src/runs/runs.service.ts
+++ b/apps/api/src/runs/runs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Prisma, Run, RunStatus } from '@prisma/client';
+import { Prisma, Run } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
 import type { PrismaService } from '../prisma/prisma.service';
@@ -17,16 +17,7 @@ export type EnqueueRunDto = {
 const MAX_ATTEMPTS_DEFAULT = 3;
 const RETRY_DELAY_MS = 150;
 
-const runStatusEnum = (RunStatus ?? {}) as Record<string, RunStatus>;
-const statusFor = (key: string, fallback: string) =>
-  (runStatusEnum && runStatusEnum[key]) ? runStatusEnum[key] : (fallback as unknown as RunStatus);
-
-const STATUS = {
-  QUEUED: statusFor('QUEUED', 'QUEUED'),
-  RUNNING: statusFor('RUNNING', 'RUNNING'),
-  SUCCEEDED: statusFor('SUCCEEDED', 'SUCCEEDED'),
-  FAILED: statusFor('ERROR', 'ERROR'),
-};
+import { RUN_STATUS } from './run-status';
 
 type QueueItem = {
   runId: string;
@@ -86,7 +77,7 @@ export class RunsService {
     const run = await this.prisma.run.create({
       data: {
         workflowId,
-        status: STATUS.QUEUED,
+        status: RUN_STATUS.PENDING,
         log: runLog as unknown as Prisma.InputJsonValue,
       } as any,
     });
@@ -160,7 +151,7 @@ export class RunsService {
       await this.prisma.run.update({
         where: { id: job.runId },
         data: {
-          status: STATUS.RUNNING,
+          status: RUN_STATUS.RUNNING,
           startedAt,
           log: log as unknown as Prisma.InputJsonValue,
           errorMessage: null,
@@ -219,7 +210,7 @@ export class RunsService {
       await this.prisma.run.update({
         where: { id: job.runId },
         data: {
-          status: STATUS.SUCCEEDED,
+          status: RUN_STATUS.SUCCESS,
           finishedAt,
           durationMs,
           errorMessage: null,
@@ -264,7 +255,7 @@ export class RunsService {
       await this.prisma.run.update({
         where: { id: job.runId },
         data: {
-          status: STATUS.QUEUED,
+          status: RUN_STATUS.PENDING,
           log: log as unknown as Prisma.InputJsonValue,
           errorMessage,
         },
@@ -282,7 +273,7 @@ export class RunsService {
       await this.prisma.run.update({
         where: { id: job.runId },
         data: {
-          status: STATUS.FAILED,
+          status: RUN_STATUS.ERROR,
           finishedAt,
           durationMs,
           errorMessage,

--- a/apps/api/src/scheduler/scheduler.service.ts
+++ b/apps/api/src/scheduler/scheduler.service.ts
@@ -5,12 +5,13 @@ import {
   OnModuleInit,
   Optional,
 } from '@nestjs/common';
-import { PrismaClient, RunStatus } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
 import { readFile } from 'fs/promises';
 import * as path from 'path';
 
 import type { GateService } from '../gates/gate.service';
 import type { RunsService } from '../runs/runs.service';
+import { RUN_STATUS } from '../runs/run-status';
 
 const DEFAULT_INTERVAL_MS = 60_000;
 
@@ -87,9 +88,8 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     if (!this.prisma) {
       return [];
     }
-    const status = (RunStatus as any).SUCCEEDED ?? RunStatus.SUCCESS ?? 'SUCCEEDED';
     return this.prisma.run.findMany({
-      where: { status: { equals: status } },
+      where: { status: { equals: RUN_STATUS.SUCCESS } },
       orderBy: { finishedAt: 'desc' },
       take: limit,
     });
@@ -132,7 +132,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     const deps = succeeded.reduce<Record<string, string>>((acc, run: any) => {
       const actionId = run?.log?.meta?.actionId;
       if (actionId) {
-        acc[actionId] = 'SUCCEEDED';
+        acc[actionId] = RUN_STATUS.SUCCESS;
       }
       return acc;
     }, {});

--- a/apps/api/test/e2e/app.e2e-spec.ts
+++ b/apps/api/test/e2e/app.e2e-spec.ts
@@ -1,8 +1,9 @@
-import { Prisma, RunStatus } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { INestApplication } from '@nestjs/common';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { RunsService } from '../../src/runs/runs.service';
 import { createTestingApp } from '../factories';
+import { RUN_STATUS } from '../../src/runs/run-status';
 
 describe('AppModule E2E', () => {
   let app: INestApplication;
@@ -48,7 +49,7 @@ describe('AppModule E2E', () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     const storedRun = runStore.get(runId);
-    expect(storedRun.status).toBe(RunStatus.SUCCEEDED);
+    expect(storedRun.status).toBe(RUN_STATUS.SUCCESS);
     expect(storedRun.log.stepLogs).toHaveLength(1);
   });
 });

--- a/apps/api/test/factories.ts
+++ b/apps/api/test/factories.ts
@@ -1,10 +1,11 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { Prisma, PrismaClient, RunStatus } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { randomUUID } from 'crypto';
 import request from 'supertest';
 import { vi } from 'vitest';
 import { AppModule } from '../src/app.module';
+import { RUN_STATUS } from '../src/runs/run-status';
 
 export type MockedPrismaResult = {
   client: PrismaClient;
@@ -21,7 +22,7 @@ export function createMockPrismaClient(
     runStore.set(id, {
       id,
       workflowId: run.workflowId ?? 'wf',
-      status: run.status ?? RunStatus.QUEUED,
+      status: run.status ?? RUN_STATUS.PENDING,
       startedAt: run.startedAt ?? new Date(),
       finishedAt: run.finishedAt ?? null,
       log: run.log ?? null,
@@ -35,7 +36,7 @@ export function createMockPrismaClient(
       const stored = {
         id,
         workflowId: data.workflowId,
-        status: data.status ?? RunStatus.QUEUED,
+        status: data.status ?? RUN_STATUS.PENDING,
         startedAt: (data as any).startedAt ?? new Date(),
         finishedAt: (data as any).finishedAt ?? null,
         log: (data as any).log ?? null,

--- a/apps/api/test/metrics.controller.spec.ts
+++ b/apps/api/test/metrics.controller.spec.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { RunStatus } from '@prisma/client';
+import type { RunStatus } from '@prisma/client';
 
 import { MetricsController } from '../src/metrics/metrics.controller';
 import { RunsService } from '../src/runs/runs.service';
@@ -9,6 +9,7 @@ import {
   silenceLogger,
   waitForRunStatus,
 } from './utils';
+import { RUN_STATUS } from '../src/runs/run-status';
 
 describe('MetricsController', () => {
   beforeAll(() => {
@@ -53,9 +54,9 @@ describe('MetricsController', () => {
       requestId: 'r3',
     });
 
-    await waitForRunStatus(service, run1, RunStatus.SUCCESS);
-    await waitForRunStatus(service, run2, RunStatus.SUCCESS);
-    await waitForRunStatus(service, run3, RunStatus.ERROR);
+    await waitForRunStatus(service, run1, RUN_STATUS.SUCCESS as RunStatus);
+    await waitForRunStatus(service, run2, RUN_STATUS.SUCCESS as RunStatus);
+    await waitForRunStatus(service, run3, RUN_STATUS.ERROR as RunStatus);
 
     const metrics = controller.get();
 

--- a/apps/api/test/runs.service.spec.ts
+++ b/apps/api/test/runs.service.spec.ts
@@ -1,8 +1,9 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { RunStatus } from '@prisma/client';
+import type { RunStatus } from '@prisma/client';
 
 import { RunsService } from '../src/runs/runs.service';
 import { createDefaultSteps, MockPrismaClient, silenceLogger, waitForRunStatus } from './utils';
+import { RUN_STATUS } from '../src/runs/run-status';
 
 const WORKFLOW_ID = '00000000-0000-0000-0000-000000000001';
 
@@ -36,10 +37,10 @@ describe('RunsService', () => {
       requestId: 'req-123',
     });
 
-    const run = await waitForRunStatus(service, runId, RunStatus.SUCCESS);
+    const run = await waitForRunStatus(service, runId, RUN_STATUS.SUCCESS as RunStatus);
 
     expect(run).not.toBeNull();
-    expect(run?.status).toBe(RunStatus.SUCCESS);
+    expect(run?.status).toBe(RUN_STATUS.SUCCESS);
     expect(run?.startedAt).toBeInstanceOf(Date);
     expect(run?.finishedAt).toBeInstanceOf(Date);
     const duration = run!.finishedAt!.getTime() - run!.startedAt!.getTime();
@@ -74,8 +75,8 @@ describe('RunsService', () => {
       requestId: 'req-err',
     });
 
-    const run = await waitForRunStatus(service, runId, RunStatus.ERROR);
-    expect(run?.status).toBe(RunStatus.ERROR);
+    const run = await waitForRunStatus(service, runId, RUN_STATUS.ERROR as RunStatus);
+    expect(run?.status).toBe(RUN_STATUS.ERROR);
     expect(run?.errorMessage).toContain('boom');
 
     const stats = service.getStats();

--- a/apps/api/test/unit/gates/gate.service.spec.ts
+++ b/apps/api/test/unit/gates/gate.service.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { GateService } from '../../../src/gates/gate.service';
+import { RUN_STATUS } from '../../../src/runs/run-status';
 import { createMockPrismaClient } from '../../factories';
 
 describe('GateService', () => {
@@ -36,8 +37,8 @@ describe('GateService', () => {
     const { client } = createMockPrismaClient();
     const service = new GateService(client);
     await expect(
-      service.checkDepsSucceeded({ A: 'SUCCEEDED', B: 'SUCCEEDED' }),
+      service.checkDepsSucceeded({ A: RUN_STATUS.SUCCESS, B: RUN_STATUS.SUCCESS }),
     ).resolves.toBe(true);
-    await expect(service.checkDepsSucceeded({ A: 'PENDING' })).resolves.toBe(false);
+    await expect(service.checkDepsSucceeded({ A: RUN_STATUS.PENDING })).resolves.toBe(false);
   });
 });

--- a/apps/api/test/unit/runs/runs.controller.spec.ts
+++ b/apps/api/test/unit/runs/runs.controller.spec.ts
@@ -6,7 +6,7 @@ describe('RunsController', () => {
   it('delegates to service methods', async () => {
     const createRun = vi.fn().mockResolvedValue({ id: 'run-1' });
     const listRecentRuns = vi.fn().mockResolvedValue([{ id: 'run-1' }]);
-    const getRun = vi.fn().mockResolvedValue({ id: 'run-1', status: 'QUEUED' });
+    const getRun = vi.fn().mockResolvedValue({ id: 'run-1', status: 'PENDING' });
 
     const runsService = {
       createRun,
@@ -26,6 +26,6 @@ describe('RunsController', () => {
 
     const fetched = await controller.get('run-1');
     expect(getRun).toHaveBeenCalledWith('run-1');
-    expect(fetched).toEqual({ id: 'run-1', status: 'QUEUED' });
+    expect(fetched).toEqual({ id: 'run-1', status: 'PENDING' });
   });
 });

--- a/apps/api/test/unit/runs/runs.service.spec.ts
+++ b/apps/api/test/unit/runs/runs.service.spec.ts
@@ -1,7 +1,8 @@
-import { Prisma, RunStatus } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { describe, expect, it, vi } from 'vitest';
 import { RunsService } from '../../../src/runs/runs.service';
 import { StepsRegistry } from '../../../src/steps/registry';
+import { RUN_STATUS } from '../../../src/runs/run-status';
 import { createMockPrismaClient } from '../../factories';
 
 describe('RunsService', () => {
@@ -16,11 +17,11 @@ describe('RunsService', () => {
       expect.objectContaining({
         data: expect.objectContaining({
           workflowId: 'wf-1',
-          status: RunStatus.QUEUED,
+          status: RUN_STATUS.PENDING,
         }),
       }),
     );
-    expect(run.status).toBe(RunStatus.QUEUED);
+    expect(run.status).toBe(RUN_STATUS.PENDING);
   });
 
   it('createRun clones provided metadata into the log', async () => {
@@ -65,7 +66,7 @@ describe('RunsService', () => {
     expect(step.run).toHaveBeenCalledWith({ foo: 'bar' });
 
     const storedRun = mockPrisma.runStore.get(run.id);
-    expect(storedRun.status).toBe(RunStatus.SUCCEEDED);
+    expect(storedRun.status).toBe(RUN_STATUS.SUCCESS);
     expect(storedRun.log.stepLogs).toHaveLength(1);
     expect(storedRun.log.stepLogs[0]).toMatchObject({ status: 'OK', output: stepResult });
   });
@@ -91,7 +92,7 @@ describe('RunsService', () => {
     await (runsService as any).processNext();
 
     const storedRun = mockPrisma.runStore.get(run.id);
-    expect(storedRun.status).toBe(RunStatus.ERROR);
+    expect(storedRun.status).toBe(RUN_STATUS.ERROR);
     expect(storedRun.log.error).toContain('boom');
     expect(failingStep.run).toHaveBeenCalled();
   });
@@ -113,7 +114,7 @@ describe('RunsService', () => {
     await (runsService as any).processNext();
 
     const storedRun = mockPrisma.runStore.get(run.id);
-    expect(storedRun.status).toBe(RunStatus.QUEUED);
+    expect(storedRun.status).toBe(RUN_STATUS.PENDING);
     expect(storedRun.log.nextAttemptAt).toBeTruthy();
 
     await vi.runOnlyPendingTimersAsync();
@@ -177,7 +178,7 @@ describe('RunsService', () => {
     mockPrisma.runStore.set(runId, {
       id: runId,
       workflowId: 'wf',
-      status: RunStatus.QUEUED,
+      status: RUN_STATUS.PENDING,
       startedAt: null,
       finishedAt: null,
       log: { stepLogs: 'invalid' } as any,
@@ -203,8 +204,8 @@ describe('RunsService', () => {
 
   it('continues processing when more jobs remain in the queue', async () => {
     const mockPrisma = createMockPrismaClient([
-      { id: 'run-1', workflowId: 'wf', status: RunStatus.QUEUED, log: { stepLogs: [] } as any },
-      { id: 'run-2', workflowId: 'wf', status: RunStatus.QUEUED, log: { stepLogs: [] } as any },
+      { id: 'run-1', workflowId: 'wf', status: RUN_STATUS.PENDING, log: { stepLogs: [] } as any },
+      { id: 'run-2', workflowId: 'wf', status: RUN_STATUS.PENDING, log: { stepLogs: [] } as any },
     ]);
     const step = { run: vi.fn().mockResolvedValue(undefined) };
     const steps = { get: vi.fn().mockReturnValue(step) } as unknown as StepsRegistry;
@@ -249,7 +250,7 @@ describe('RunsService', () => {
     (runsService as any).queue.length = 0;
     mockPrisma.runStore.set(run.id, {
       ...mockPrisma.runStore.get(run.id),
-      status: RunStatus.RUNNING,
+      status: RUN_STATUS.RUNNING,
       log: { attempts: 2, maxAttempts: 3, stepLogs: [] },
     });
 
@@ -259,7 +260,7 @@ describe('RunsService', () => {
     );
 
     const stored = mockPrisma.runStore.get(run.id);
-    expect(stored.status).toBe(RunStatus.ERROR);
+    expect(stored.status).toBe(RUN_STATUS.ERROR);
     expect(stored.log.error).toBe('catastrophic');
   });
 });

--- a/apps/api/test/unit/scheduler/scheduler.service.spec.ts
+++ b/apps/api/test/unit/scheduler/scheduler.service.spec.ts
@@ -1,11 +1,12 @@
 import { Logger } from '@nestjs/common';
-import { Prisma, RunStatus } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import * as fs from 'fs';
 import * as path from 'path';
 import { describe, expect, it, vi } from 'vitest';
 import { GateService } from '../../../src/gates/gate.service';
 import { RunsService } from '../../../src/runs/runs.service';
 import { SchedulerService } from '../../../src/scheduler/scheduler.service';
+import { RUN_STATUS } from '../../../src/runs/run-status';
 import { createMockPrismaClient } from '../../factories';
 
 describe('SchedulerService', () => {
@@ -47,7 +48,7 @@ describe('SchedulerService', () => {
 
     await service.getSucceededRuns(5);
     expect(mockPrisma.client.run.findMany).toHaveBeenCalledWith({
-      where: { status: { equals: RunStatus.SUCCEEDED } },
+      where: { status: { equals: RUN_STATUS.SUCCESS } },
       orderBy: { finishedAt: 'desc' },
       take: 5,
     });
@@ -57,7 +58,7 @@ describe('SchedulerService', () => {
     const mockPrisma = createMockPrismaClient([
       {
         id: 'run-1',
-        status: RunStatus.SUCCEEDED,
+        status: RUN_STATUS.SUCCESS,
         log: { meta: { actionId: 'other-action' } },
       },
     ]);


### PR DESCRIPTION
## Summary
- add a run status compatibility helper that maps legacy values to the Prisma enum
- update services, controllers, and scheduler logic to rely on the shared helper
- adjust tests and factories to expect the Prisma enum values and keep E2E coverage

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e46085d26c8325be6189560107e972