### PR TITLE
Fix run status helper to match Prisma enum

### DIFF
--- a/apps/api/src/runs/run-status.ts
+++ b/apps/api/src/runs/run-status.ts
@@ -1,4 +1,12 @@
-type RunStatus = string;
+type PrismaClientModule = typeof import('@prisma/client');
+
+type PrismaRunStatus = PrismaClientModule extends { RunStatus: infer EnumObject }
+  ? EnumObject extends Record<string, infer EnumValue>
+    ? EnumValue
+    : never
+  : string;
+
+type RunStatus = PrismaRunStatus;
 
 type RunStatusRecord = Record<string, RunStatus>;
 


### PR DESCRIPTION
## Summary
- derive the run status helper type from Prisma's generated enum values while keeping the string fallback

## Testing
- pnpm --filter api test

------
https://chatgpt.com/codex/tasks/task_e_68e4668568a883259d34c2b2ed280f7f