### PR TITLE
fix(api): ensure scheduler dependencies are resolvable

### DIFF
--- a/apps/api/src/scheduler/scheduler.service.ts
+++ b/apps/api/src/scheduler/scheduler.service.ts
@@ -10,8 +10,8 @@ import { readFile } from 'fs/promises';
 import * as path from 'path';
 
 import { PrismaService } from '../prisma/prisma.service';
-import type { GateService } from '../gates/gate.service';
-import type { RunWithLog, RunsService } from '../runs/runs.service';
+import { GateService } from '../gates/gate.service';
+import { RunsService, type RunWithLog } from '../runs/runs.service';
 import { RUN_STATUS } from '../runs/run-status';
 
 const DEFAULT_INTERVAL_MS = 60_000;


### PR DESCRIPTION
## Summary
- import the SchedulerService dependencies as runtime values so Nest can inject RunsService and GateService correctly

## Testing
- pnpm --filter api start *(fails: @prisma/client did not initialize yet. Run `prisma generate` before starting the API)*

------
https://chatgpt.com/codex/tasks/task_e_68e46ba7e7b483258d4bbe5f3f695f4e