### PR TITLE
Fix metrics controller dependency injection

### DIFF
--- a/apps/api/src/metrics/metrics.controller.ts
+++ b/apps/api/src/metrics/metrics.controller.ts
@@ -20,7 +20,7 @@ export class MetricsController {
   private readonly startedAt = Date.now();
 
   constructor(
-    @Optional() private readonly runsMaybe?: RunsService | PrismaService,
+    @Optional() private readonly runsMaybe?: RunsService,
     @Optional() private readonly prismaMaybe?: PrismaService,
   ) {
     if (!this.runsMaybe && !this.prismaMaybe) {

--- a/apps/api/test/unit/metrics/metrics.controller.spec.ts
+++ b/apps/api/test/unit/metrics/metrics.controller.spec.ts
@@ -5,7 +5,7 @@ import { createMockPrismaClient } from '../../factories';
 describe('MetricsController', () => {
   it('returns aggregated metrics', async () => {
     const mock = createMockPrismaClient();
-    const controller = new MetricsController(mock.client);
+    const controller = new MetricsController(undefined, mock.client);
 
     mock.client.run.count = vi
       .fn()
@@ -25,7 +25,7 @@ describe('MetricsController', () => {
 
   it('returns zero error rate when there are no runs', async () => {
     const mock = createMockPrismaClient();
-    const controller = new MetricsController(mock.client);
+    const controller = new MetricsController(undefined, mock.client);
 
     mock.client.run.count = vi.fn().mockResolvedValueOnce(0).mockResolvedValueOnce(0);
 


### PR DESCRIPTION
## Summary
- ensure the metrics controller constructor only requests concrete services so Nest can inject dependencies
- adjust metrics controller unit tests to pass the Prisma mock in the correct constructor slot

## Testing
- pnpm --dir apps/api exec vitest run --run test/unit/metrics/metrics.controller.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e46d49a4ec8325ad6ef691ae896f06