### PR TITLE
Add missing log column to Run Prisma model

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Run {
   finishedAt DateTime?
   error      String?
   meta       Json?
+  log        Json?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Summary
- add the missing `log` JSON field to the Prisma Run model so run creation can persist execution logs
- regenerate the Prisma client to ensure the new column is available to the application layer

## Testing
- pnpm --filter api test

------
https://chatgpt.com/codex/tasks/task_e_68e4757ab408832587c1478dadcc6394