### PR TITLE
Fix run schema to support log metadata

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -42,9 +42,12 @@ model Run {
   status     RunStatus @default(PENDING)
   startedAt  DateTime?
   finishedAt DateTime?
-  error      String?
-  meta       Json?
-  log        Json?
+  error        String?
+  errorMessage String?
+  durationMs   Int?
+  meta         Json?
+  log          Json?
+  spec         Json?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Summary
- add missing run columns for error message, duration, log, and spec metadata to the Prisma schema so the API can persist run logs

## Testing
- pnpm --filter api prisma:generate
- pnpm --filter api test

------
https://chatgpt.com/codex/tasks/task_e_68e4766793108325bbc87ec89505c2d4