### PR TITLE
fix: ensure scheduler workflows exist before runs

### DIFF
--- a/apps/api/src/scheduler/scheduler.service.ts
+++ b/apps/api/src/scheduler/scheduler.service.ts
@@ -109,8 +109,9 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     }
 
     for (const action of this.plan.schedule) {
+      const workflowId = await this.ensureWorkflowId(action);
       await enqueue.call(this.runs, {
-        workflowId: action.workflowId,
+        workflowId,
         nodes: action.nodes,
         meta: { actionId: action.id, level: action.level },
         requestId: `scheduler-${Date.now()}`,
@@ -149,14 +150,58 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       return { ok: false };
     }
 
+    const workflowId = await this.ensureWorkflowId(firstAction);
     await (this.runs.createRun as Function).call(
       this.runs,
-      firstAction.workflowId,
+      workflowId,
       firstAction.nodes,
       { actionId: firstAction.id, level: firstAction.level },
     );
 
     return { ok: true };
+  }
+
+  private async ensureWorkflowId(action: any): Promise<string> {
+    const identifier = action?.workflowId;
+    if (!identifier || !this.prisma) {
+      return identifier;
+    }
+
+    const byId = await this.prisma.workflow.findUnique({ where: { id: identifier } });
+    if (byId) {
+      return byId.id;
+    }
+
+    const byKey = await this.prisma.workflow.findUnique({ where: { key: identifier } });
+    if (byKey) {
+      return byKey.id;
+    }
+
+    const name = this.deriveWorkflowName(action?.workflowName ?? identifier);
+    const description =
+      action?.workflowDescription ?? 'Generado automáticamente por el scheduler bootstrap';
+
+    const created = await this.prisma.workflow.create({
+      data: {
+        key: identifier,
+        name,
+        description,
+        isActive: true,
+      },
+    });
+
+    this.logger.log(`Workflow ${identifier} creado automáticamente`);
+    return created.id;
+  }
+
+  private deriveWorkflowName(input: string): string {
+    const value = input?.trim();
+    if (!value) {
+      return 'Workflow generado';
+    }
+
+    const spaced = value.replace(/[-_.]+/g, ' ');
+    return spaced.replace(/\b\w/g, (char) => char.toUpperCase());
   }
 
   private async loadPlan() {

--- a/apps/api/test/factories.ts
+++ b/apps/api/test/factories.ts
@@ -10,12 +10,15 @@ import { RUN_STATUS } from '../src/runs/run-status';
 export type MockedPrismaResult = {
   client: PrismaClient;
   runStore: Map<string, any>;
+  workflowStore: Map<string, any>;
 };
 
 export function createMockPrismaClient(
   initialRuns: Array<Partial<Prisma.Run>> = [],
+  initialWorkflows: Array<Partial<Prisma.Workflow>> = [],
 ): MockedPrismaResult {
   const runStore = new Map<string, any>();
+  const workflowStore = new Map<string, any>();
 
   initialRuns.forEach((run) => {
     const id = run.id ?? randomUUID();
@@ -27,6 +30,20 @@ export function createMockPrismaClient(
       finishedAt: run.finishedAt ?? null,
       log: run.log ?? null,
       ...run,
+    });
+  });
+
+  initialWorkflows.forEach((workflow) => {
+    const id = workflow.id ?? randomUUID();
+    const key = workflow.key ?? id;
+    workflowStore.set(id, {
+      id,
+      key,
+      name: workflow.name ?? key,
+      description: workflow.description ?? null,
+      isActive: workflow.isActive ?? true,
+      createdAt: workflow.createdAt ?? new Date(),
+      updatedAt: workflow.updatedAt ?? new Date(),
     });
   });
 
@@ -95,12 +112,69 @@ export function createMockPrismaClient(
     }),
   };
 
+  const workflowModel = {
+    findUnique: vi.fn(async ({ where }: { where: { id?: string; key?: string } }) => {
+      if (where.id) {
+        const match = workflowStore.get(where.id);
+        return match ? { ...match } : null;
+      }
+      if (where.key) {
+        const match = Array.from(workflowStore.values()).find((wf) => wf.key === where.key);
+        return match ? { ...match } : null;
+      }
+      return null;
+    }),
+    create: vi.fn(async ({ data }: { data: Prisma.WorkflowCreateInput }) => {
+      const id = (data as any).id ?? randomUUID();
+      const stored = {
+        id,
+        key: data.key,
+        name: data.name,
+        description: data.description ?? null,
+        isActive: data.isActive ?? true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      workflowStore.set(id, stored);
+      return { ...stored } as Prisma.Workflow;
+    }),
+    upsert: vi.fn(async ({
+      where,
+      create,
+      update,
+    }: {
+      where: { key: string };
+      create: Prisma.WorkflowCreateInput;
+      update: Prisma.WorkflowUpdateInput;
+    }) => {
+      const existing = Array.from(workflowStore.values()).find((wf) => wf.key === where.key);
+      if (existing) {
+        const updated = { ...existing, ...update, updatedAt: new Date() };
+        workflowStore.set(existing.id, updated);
+        return { ...updated } as Prisma.Workflow;
+      }
+      const id = (create as any).id ?? randomUUID();
+      const stored = {
+        id,
+        key: create.key,
+        name: create.name,
+        description: create.description ?? null,
+        isActive: create.isActive ?? true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      workflowStore.set(id, stored);
+      return { ...stored } as Prisma.Workflow;
+    }),
+  };
+
   const client = {
     run: runModel,
+    workflow: workflowModel,
     $queryRaw: vi.fn(async () => 1),
   } as unknown as PrismaClient;
 
-  return { client, runStore };
+  return { client, runStore, workflowStore };
 }
 
 export async function createTestingApp(overrides?: {

--- a/apps/api/test/unit/scheduler/scheduler.service.spec.ts
+++ b/apps/api/test/unit/scheduler/scheduler.service.spec.ts
@@ -55,13 +55,14 @@ describe('SchedulerService', () => {
   });
 
   it('tick enqueues workflow when gates succeed', async () => {
+    const workflow = { id: 'wf-existing', key: firstAction.workflowId, name: 'Bootstrap' };
     const mockPrisma = createMockPrismaClient([
       {
         id: 'run-1',
         status: RUN_STATUS.SUCCESS,
         log: { meta: { actionId: 'other-action' } },
       },
-    ]);
+    ], [workflow]);
     const runs = { createRun: vi.fn().mockResolvedValue(undefined) } as unknown as RunsService;
     const gates = {
       checkEnv: vi.fn().mockResolvedValue(true),
@@ -74,7 +75,7 @@ describe('SchedulerService', () => {
 
     expect(result).toEqual({ ok: true });
     expect(runs.createRun).toHaveBeenCalledWith(
-      firstAction.workflowId,
+      workflow.id,
       firstAction.nodes,
       {
         actionId: firstAction.id,


### PR DESCRIPTION
## Summary
- resolve scheduler plan workflow identifiers to persisted workflows before creating runs
- extend the prisma test factory with workflow support for the new resolution logic
- adjust scheduler unit coverage to expect resolved workflow identifiers

## Testing
- pnpm -C apps/api test

------
https://chatgpt.com/codex/tasks/task_e_68e47c172b208325988746fa0af4c9d3