### PR TITLE
Ensure Prisma client is generated before starting API

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,9 +8,13 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "prestart": "prisma generate --schema=prisma/schema.prisma",
     "start": "nest start",
+    "prestart:debug": "prisma generate --schema=prisma/schema.prisma",
     "start:debug": "nest start --debug --watch",
+    "prestart:prod": "prisma generate --schema=prisma/schema.prisma",
     "start:prod": "node dist/main",
+    "prestart:dev": "prisma generate --schema=prisma/schema.prisma",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test:cov": "vitest run --coverage",
     "test:debug": "vitest run --sequence",


### PR DESCRIPTION
## Summary
- regenerate the Prisma client automatically before every API start command so runtime schema changes like `durationMs` are always reflected

## Testing
- pnpm --dir apps/api test

------
https://chatgpt.com/codex/tasks/task_e_68e47f02d32c8325bca9b7a82b76a72c