### PR TITLE
Handle missing Run.errorMessage column in scheduler

### DIFF
--- a/apps/api/src/scheduler/scheduler.service.ts
+++ b/apps/api/src/scheduler/scheduler.service.ts
@@ -6,6 +6,7 @@ import {
   Optional,
 } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { readFile } from 'fs/promises';
 import * as path from 'path';
 
@@ -41,6 +42,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
   private readonly runs: RunsLike;
   private readonly gates?: GateLike;
   private readonly prisma?: PrismaClient;
+  private errorMessageColumnAvailable: boolean | null = null;
 
   constructor(
     runsService: RunsService,
@@ -95,11 +97,26 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     if (!this.prisma) {
       return [];
     }
-    return (await this.prisma.run.findMany({
-      where: { status: { equals: RUN_STATUS.SUCCESS } },
-      orderBy: { finishedAt: 'desc' },
-      take: limit,
-    })) as RunWithLog[];
+
+    const query = this.buildSucceededRunsQuery(limit);
+
+    try {
+      const runs = (await this.prisma.run.findMany(query)) as RunWithLog[];
+      if (this.errorMessageColumnAvailable !== false) {
+        this.errorMessageColumnAvailable = true;
+      }
+      return runs.map((run) => this.ensureErrorMessage(run));
+    } catch (error) {
+      if (this.shouldHandleMissingErrorMessageColumn(error)) {
+        this.errorMessageColumnAvailable = false;
+        const fallbackRuns = (await this.prisma.run.findMany(
+          this.buildSucceededRunsQuery(limit),
+        )) as RunWithLog[];
+        return fallbackRuns.map((run) => this.ensureErrorMessage(run));
+      }
+
+      throw error;
+    }
   }
 
   private async tickSimple() {
@@ -217,5 +234,54 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     }
 
     this.plan = null;
+  }
+
+  private buildSucceededRunsQuery(limit: number) {
+    const baseQuery = {
+      where: { status: { equals: RUN_STATUS.SUCCESS } },
+      orderBy: { finishedAt: 'desc' as const },
+      take: limit,
+    };
+
+    if (this.errorMessageColumnAvailable === false) {
+      return {
+        ...baseQuery,
+        select: {
+          id: true,
+          workflowId: true,
+          status: true,
+          startedAt: true,
+          finishedAt: true,
+          meta: true,
+          createdAt: true,
+          updatedAt: true,
+          log: true,
+          error: true,
+          durationMs: true,
+        },
+      };
+    }
+
+    return baseQuery;
+  }
+
+  private ensureErrorMessage(run: RunWithLog): RunWithLog {
+    if (run.errorMessage !== undefined) {
+      return run;
+    }
+
+    return {
+      ...run,
+      errorMessage: run.error ?? null,
+    };
+  }
+
+  private shouldHandleMissingErrorMessageColumn(error: unknown) {
+    return (
+      error instanceof PrismaClientKnownRequestError &&
+      error.code === 'P2022' &&
+      typeof error.meta === 'object' &&
+      error.meta?.column === 'Run.errorMessage'
+    );
   }
 }

--- a/apps/api/test/unit/scheduler/scheduler.service.spec.ts
+++ b/apps/api/test/unit/scheduler/scheduler.service.spec.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import * as fs from 'fs';
 import * as path from 'path';
 import { describe, expect, it, vi } from 'vitest';
@@ -51,6 +52,79 @@ describe('SchedulerService', () => {
       where: { status: { equals: RUN_STATUS.SUCCESS } },
       orderBy: { finishedAt: 'desc' },
       take: 5,
+    });
+  });
+
+  it('getSucceededRuns retries without errorMessage column when missing', async () => {
+    const knownError = new PrismaClientKnownRequestError('Column does not exist', {
+      code: 'P2022',
+      clientVersion: '6.16.3',
+      meta: { column: 'Run.errorMessage' },
+    });
+
+    const fallbackRun = {
+      id: 'run-1',
+      workflowId: 'wf',
+      status: RUN_STATUS.SUCCESS,
+      startedAt: new Date(),
+      finishedAt: new Date(),
+      meta: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      log: { meta: { actionId: 'action-1' } },
+      error: 'boom',
+      durationMs: 100,
+    };
+
+    const mockPrisma = createMockPrismaClient();
+    const findMany = vi
+      .fn()
+      .mockRejectedValueOnce(knownError)
+      .mockResolvedValueOnce([fallbackRun]);
+
+    mockPrisma.client.run.findMany = findMany as any;
+
+    const service = new SchedulerService(
+      { createRun: vi.fn() } as unknown as RunsService,
+      {
+        checkEnv: vi.fn(),
+        checkDbReachable: vi.fn(),
+        checkDepsSucceeded: vi.fn(),
+      } as unknown as GateService,
+      mockPrisma.client,
+    );
+
+    const runs = await service.getSucceededRuns(2);
+
+    expect(findMany).toHaveBeenNthCalledWith(1, {
+      where: { status: { equals: RUN_STATUS.SUCCESS } },
+      orderBy: { finishedAt: 'desc' },
+      take: 2,
+    });
+
+    expect(findMany).toHaveBeenNthCalledWith(2, {
+      where: { status: { equals: RUN_STATUS.SUCCESS } },
+      orderBy: { finishedAt: 'desc' },
+      take: 2,
+      select: {
+        id: true,
+        workflowId: true,
+        status: true,
+        startedAt: true,
+        finishedAt: true,
+        meta: true,
+        createdAt: true,
+        updatedAt: true,
+        log: true,
+        error: true,
+        durationMs: true,
+      },
+    });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      id: 'run-1',
+      errorMessage: 'boom',
     });
   });
 


### PR DESCRIPTION
## Summary
- retry SchedulerService run lookups without the errorMessage column when the database does not expose it
- normalise run data so errorMessage falls back to the legacy error field
- add unit coverage that simulates the missing column scenario

## Testing
- pnpm --filter api test

------
https://chatgpt.com/codex/tasks/task_e_68e480595150832593ced4eac8d638d8